### PR TITLE
Add description for FeedTicker

### DIFF
--- a/SharpExchange/Chat/Events/EventType.cs
+++ b/SharpExchange/Chat/Events/EventType.cs
@@ -115,7 +115,7 @@
 		TimeBreak = 21,
 
 		/// <summary>
-		/// No idea.
+		/// New item in the feeds received.
 		/// </summary>
 		FeedTicker = 22,
 


### PR DESCRIPTION
When a room is configured to have items posted in the feeds ticker (described on site as "via a slide-down ticker overlay at the top of the room"), event 22 is triggered when new items arrive.