### PR TITLE
Add a few more descriptions to event types.

### DIFF
--- a/SharpExchange/Chat/Events/EventType.cs
+++ b/SharpExchange/Chat/Events/EventType.cs
@@ -38,12 +38,12 @@
 		MessageStarToggled = 6,
 
 		/// <summary>
-		/// No idea.
+		/// No idea. Browser simply logs the content of this event.
 		/// </summary>
 		DebugMessage = 7,
 
 		/// <summary>
-		/// The current account has been mentioned (@Username) in a message.
+		/// The current account has been mentioned (@Username) in a message. May originate from another room.
 		/// </summary>
 		UserMentioned = 8,
 
@@ -70,12 +70,13 @@
 		ModeratorFlag = 12,
 
 		/// <summary>
-		/// No idea.
+		/// User is ignored or un-ignored.
 		/// </summary>
 		UserSettingsChanged = 13,
 
 		/// <summary>
-		/// No idea.
+		/// Notifications displayed as a banner in a room. Does not include room invitations. 
+		/// For example, room events starting.
 		/// </summary>
 		GlobalNotification = 14,
 
@@ -85,7 +86,7 @@
 		UserAccessLevelChanged = 15,
 
 		/// <summary>
-		/// No idea.
+		/// Not sure which events trigger this. Behaves the same as GlobalNotification in the web browser.
 		/// </summary>
 		UserNotification = 16,
 
@@ -95,7 +96,7 @@
 		RoomInvitation = 17,
 
 		/// <summary>
-		/// Someone has posted a direct reply to a message posted by this account.
+		/// Someone has posted a direct reply to a message posted by this account. May originate from another room.
 		/// </summary>
 		MessageReply = 18,
 
@@ -115,7 +116,7 @@
 		TimeBreak = 21,
 
 		/// <summary>
-		/// No idea.
+		/// New item in the room's feed ticker received.
 		/// </summary>
 		FeedTicker = 22,
 


### PR DESCRIPTION
TimeBreak appears to be related to the time gap displays and monologues. Wasn't able to see that event after an hour of inactivity, however.

Kicks display a notification to room owners and mods, but unsure whether the event is GlobalNotification or UserNotification.