### PR TITLE
Make dispose safer

### DIFF
--- a/SharpExchange/Chat/Events/RoomWatcher.cs
+++ b/SharpExchange/Chat/Events/RoomWatcher.cs
@@ -61,8 +61,8 @@ namespace SharpExchange.Chat.Events
 			if (dispose) return;
 			dispose = true;
 
-			EventRouter.Dispose();
-			WebSocket.Dispose();
+			EventRouter?.Dispose();
+			WebSocket?.Dispose();
 
 			GC.SuppressFinalize(this);
 		}


### PR DESCRIPTION
So while I made my own login method that repeatedly asks for credentials if they're wrong, I somehow got an NRE in the dispose method of the roomwatcher. Not completely sure how that happened, but in case it happens again, here's the fix for it.

What do you think about an explicit login method? If the one I build is refined and nice, I could try and integrate it somewhere fitting.